### PR TITLE
CASMPET-7221 update docker-kubectl version and set_node_labels.sh script

### DIFF
--- a/kubernetes/cray-node-labels/Chart.yaml
+++ b/kubernetes/cray-node-labels/Chart.yaml
@@ -1,8 +1,8 @@
 #
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021,2024 Hewlett Packard Enterprise Development LP
 #
 apiVersion: v2
-version: 0.4.1
+version: 0.5.0
 name: cray-node-labels
 description: Create labels for kubernetes nodes
 keywords:
@@ -16,9 +16,9 @@ sources:
 maintainers:
   - name: bo-quan
     url: https://github.com/bo-quan
-appVersion: 1.19.15
+appVersion: 1.24.17
 annotations:
   artifacthub.io/images: |
     - name: docker-kubectl
-      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.19.15
+      image: artifactory.algol60.net/csm-docker/stable/docker-kubectl:1.24.17
   artifacthub.io/license: MIT

--- a/kubernetes/cray-node-labels/files/set_node_labels.sh
+++ b/kubernetes/cray-node-labels/files/set_node_labels.sh
@@ -1,12 +1,12 @@
-#!/bin/bash
+#!/bin/sh
 #
-# Copyright 2021 Hewlett Packard Enterprise Development LP
+# Copyright 2021, 2024 Hewlett Packard Enterprise Development LP
 #
 for line in $(cat /scripts/node_labels)
 do
   cnt=0
-  IFS=':' list=($line)
-  for item in "${list[@]}"
+  IFS=':' list="$line"
+  for item in $list
   do
     cnt=$((cnt+1))
     if [ "$cnt" -eq 1 ]; then
@@ -14,8 +14,8 @@ do
       continue
     fi
     cnt2=0
-    IFS='=' list2=($item)
-    for item2 in "${list2[@]}"
+    IFS='=' list2="$item"
+    for item2 in $list2
     do
       cnt2=$((cnt2+1))
       if [ "$cnt2" -eq 1 ]; then
@@ -25,7 +25,7 @@ do
       fi
     done
     echo "Setting label: $key to value: $value for node: $node"
-    kubectl label node $node "$key=$value" --overwrite
+    kubectl label node "$node" "$key=$value" --overwrite
     rc=$?
     if [ "$rc" -ne 0 ]; then
       echo "ERROR: Failed to set label: $key to value: $value for node: $node"


### PR DESCRIPTION
## Summary and Scope

For k8s 1.24 in CSM 1.6, the docker-kubectl container image should be updated so that it is using version 1.24.17.

When testing this change, I found that the existing script did not work. `set_node_labels.sh` was failing with the following output.

```
Cray-node-labels Original output
ncn-m001:~/leliasen # kubectl logs -n services cray-node-labels-5f4bd8fdfb-8spgb
Fri Sep 13 18:37:59 UTC 2024
/bin/sh: /scripts/set_node_labels.sh: not found
```

This error occurred because the shebang of the script was `/bin/bash` and the container only has `/bin/sh`. This PR edits `set_node_labels.sh` so that it works properly with `/bin/sh`.

## Issues and Related PRs

* Relates to [CASMPET-7221](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7221)

## Testing

### Tested on:

  * Beau (vshasta2)

### Test description:

1. Tested chart upgrade. (It say ncn-m001 not labeled because it already had the label)

```
ncn-m001:~/leliasen # kubectl logs -n services cray-node-labels-6c7cc4c5f8-pvvwz
Fri Sep 13 18:40:50 UTC 2024
Setting label: no_external_access to value: False for node: ncn-m001
node/ncn-m001 not labeled
```

2. Edited values.yaml so that the following labels would be created by the chart.

```
nodeLabels:
  - ncn-m001:no_external_access=False
  - ncn-m002:test1=this
  - ncn-w003:test2=True
```
 
I uninstalled and reinstalled the chart and the pod showed the following output.

```
ncn-m001:~/leliasen # kubectl logs -n services cray-node-labels-6c7cc4c5f8-92vrt
Fri Sep 13 18:47:28 UTC 2024
Setting label: no_external_access to value: False for node: ncn-m001
node/ncn-m001 labeled
Setting label: test1 to value: this for node: ncn-m002
node/ncn-m002 labeled
Setting label: test2 to value: True for node: ncn-w003
node/ncn-w003 labeled
```

```
ncn-m001:~/leliasen # kubectl get nodes --show-labels
NAME       STATUS   ROLES           AGE   VERSION    LABELS
ncn-m001   Ready    control-plane   13h   v1.24.17   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=ncn-m001,kubernetes.io/os=linux,no_external_access=False,node-role.kubernetes.io/control-plane=,node.kubernetes.io/exclude-from-external-load-balancers=
ncn-m002   Ready    control-plane   14h   v1.24.17   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=ncn-m002,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node.kubernetes.io/exclude-from-external-load-balancers=,test1=this
ncn-m003   Ready    control-plane   14h   v1.24.17   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,kubernetes.io/arch=amd64,kubernetes.io/hostname=ncn-m003,kubernetes.io/os=linux,node-role.kubernetes.io/control-plane=,node.kubernetes.io/exclude-from-external-load-balancers=
ncn-w001   Ready    <none>          14h   v1.24.17   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,katacontainers.io/kata-runtime=true,kubernetes.io/arch=amd64,kubernetes.io/hostname=ncn-w001,kubernetes.io/os=linux,node-discovery.cray.com/networks.node_management=true,node-discovery.cray.com/running=true,vshasta.metallb.target=target
ncn-w002   Ready    <none>          14h   v1.24.17   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,katacontainers.io/kata-runtime=true,kubernetes.io/arch=amd64,kubernetes.io/hostname=ncn-w002,kubernetes.io/os=linux,node-discovery.cray.com/networks.node_management=true,node-discovery.cray.com/running=true,vshasta.metallb.target=target
ncn-w003   Ready    <none>          14h   v1.24.17   beta.kubernetes.io/arch=amd64,beta.kubernetes.io/os=linux,katacontainers.io/kata-runtime=true,kubernetes.io/arch=amd64,kubernetes.io/hostname=ncn-w003,kubernetes.io/os=linux,node-discovery.cray.com/networks.node_management=true,node-discovery.cray.com/running=true,node.kubernetes.io/exclude-from-external-load-balancers=,test2=True
```


## Risks and Mitigations

Low risk

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

